### PR TITLE
Mempool Cost Updates

### DIFF
--- a/dashboards/blockchain/mempool-transactions-fees.json
+++ b/dashboards/blockchain/mempool-transactions-fees.json
@@ -111,7 +111,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -203,7 +204,8 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "short",
+          "unitScale": true
         },
         "overrides": [
           {
@@ -260,13 +262,27 @@
             "type": "prometheus",
             "uid": "PB06BBC9CA81C548D"
           },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "sum without(cluster, application, component, pod, service, instance, namespace, job, instance_name, ref, container, group, endpoint, region) (\n  topk(1, chia_full_node_mempool_max_total_cost{network=\"$network\"})!=0\n)",
+          "expr": "sum without(cluster, application, component, pod, service, instance, namespace, job, instance_name, ref, container, group, endpoint, region) (\n  bottomk(1, chia_full_node_mempool_max_total_cost{network=\"$network\"})!=0\n)",
           "hide": false,
           "instant": false,
           "interval": "",
-          "legendFormat": "Max Cost",
+          "legendFormat": "Max Mempool Cost",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PB06BBC9CA81C548D"
+          },
+          "editorMode": "code",
+          "expr": "sum without(cluster, application, component, pod, service, instance, namespace, job, instance_name, ref, container, group, endpoint, region) (\n    topk(1, chia_full_node_block_max_cost{network=\"$network\"}) * 0.6\n)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "60% Block Limit",
+          "range": true,
+          "refId": "C"
         }
       ],
       "title": "Mempool Cost",
@@ -355,7 +371,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -453,7 +470,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "unitScale": true
         },
         "overrides": [
           {
@@ -616,7 +634,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unitScale": true
         },
         "overrides": []
       },
@@ -740,7 +759,8 @@
               }
             ]
           },
-          "unit": "XCH"
+          "unit": "XCH",
+          "unitScale": true
         },
         "overrides": [
           {
@@ -887,7 +907,8 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "none",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1006,7 +1027,8 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "none",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1129,7 +1151,8 @@
               }
             ]
           },
-          "unit": "mojos"
+          "unit": "mojos",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1259,7 +1282,8 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "none",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1378,7 +1402,8 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "none",
+          "unitScale": true
         },
         "overrides": []
       },
@@ -1490,6 +1515,6 @@
   "timezone": "",
   "title": "Mempool, Transactions, & Fees",
   "uid": "46EAA05E",
-  "version": 4,
+  "version": 9,
   "weekStart": ""
 }


### PR DESCRIPTION
* Add a 60% block limit line to mempool graph. 
* Swap the mempool max cost line to show the lowest of reporting nodes, to show current version's lower limit

![Screenshot 2024-02-05 at 8 27 36 PM](https://github.com/Chia-Network/pub-metrics-grafana/assets/1915905/0b86f42e-3e5f-481b-967f-31d7d344e8db)
