### PR TITLE
Switch back to latest grafana

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:10.4.5
+FROM grafana/grafana:latest
 
 ENV GF_INSTALL_PLUGINS=grafana-worldmap-panel
 


### PR DESCRIPTION
This was pinned to a previous release of Grafana a month or so back because we began seeing issues in a new major release of Grafana. Grafana 11 has been out for some time now, and has seen a few releases since then, so we should try out on latest again so we don't end up falling far behind.