### PR TITLE
Add ping route to Grafana allowed routes

### DIFF
--- a/helm/values.yaml.j2
+++ b/helm/values.yaml.j2
@@ -17,7 +17,7 @@ ingress:
       location ~ ^/(swagger|metrics|admin|datasources|connections/datasources|openapi) {
         return 403;
       }
-      if ($uri ~ ^/api/(?!(search(/|$)|frontend-metrics(/|$)|plugins(/|$)|folders(/|$)|annotations(/|$)|ds/query(/|$)|dashboards/home(/|$)|datasources/uid/PB06BBC9CA81C548D/resources/api/v1/(query|label/network/values)(/|$)))) {
+      if ($uri ~ ^/api/(?!(login/ping(/|$)|search(/|$)|frontend-metrics(/|$)|plugins(/|$)|folders(/|$)|annotations(/|$)|ds/query(/|$)|dashboards/home(/|$)|datasources/uid/PB06BBC9CA81C548D/resources/api/v1/(query|label/network/values)(/|$)))) {
         return 403;
       }
 


### PR DESCRIPTION
Adds the /api/login/ping route to allowed routes

Solving:
<img width="604" height="278" alt="image" src="https://github.com/user-attachments/assets/a2958517-795e-4f5c-b558-cce6618eb91c" />
