### PR TITLE
Have github glue called only once when workflow runs

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -89,6 +89,7 @@ jobs:
           kubectl apply -n grafana-pub -f helm/httpproxy.yaml
 
       - name: Trigger downstream workflows
+        if: matrix.colo.region == 'fmt'
         uses: Chia-Network/actions/github/glue@main
         with:
           glue_url: ${{ secrets.GLUE_API_URL }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single CI guard on a non-deploy glue step; deploy matrix behavior is unchanged aside from avoiding duplicate downstream triggers.
> 
> **Overview**
> The **Build & Deploy** workflow deploys to four colo regions in parallel (`fmt`, `msp`, `zrh`, `sin`). The **Trigger downstream workflows** step that calls Chia GitHub glue ran on every matrix leg, so each push could fire glue four times.
> 
> This PR adds `if: matrix.colo.region == 'fmt'` so glue runs only on the `fmt` deploy job—**one** downstream trigger per workflow run while all regions still deploy as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c41e4cae12283ce20223b85b16c16f36876dde60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->